### PR TITLE
Correctly removes nodes

### DIFF
--- a/modules/DoublyLinkedList.py
+++ b/modules/DoublyLinkedList.py
@@ -64,6 +64,7 @@ class DoublyLinkedList:
     def remove_first(self):
         """ Removes and returns the value from the first node. """
         val = self.sentinel.next.val
+        self.__sentinel.next.next.prev = self.__sentinel
         self.__sentinel.next = self.__sentinel.next.next
 
         return val
@@ -72,6 +73,7 @@ class DoublyLinkedList:
         """ removes and returns the value from the last node. """
         val = self.__sentinel.prev.val
         self.__sentinel.prev.prev.next = self.__sentinel
+        self.__sentinel.prev = self.sentinel.prev.prev
 
         return val
 

--- a/unittests/DoublyLinkedListTest.py
+++ b/unittests/DoublyLinkedListTest.py
@@ -101,6 +101,9 @@ class DoublyLinkedListTester(unittest.TestCase):
 
         self.assertEqual(dll.remove_first(), 5)
         self.assertEqual(dll.__str__(), "[7, 11]")
+        self.assertEqual(dll.remove_first(), 7)
+        self.assertEqual(dll.remove_first(), 11)
+        self.assertIsNone(dll.remove_first())
 
     def test_remove_last(self):
         """ Tests removing the last node in DLL. """
@@ -111,6 +114,9 @@ class DoublyLinkedListTester(unittest.TestCase):
 
         self.assertEqual(dll.remove_last(), 11)
         self.assertEqual(dll.__str__(), "[5, 7]")
+        self.assertEqual(dll.remove_last(), 7)
+        self.assertEqual(dll.remove_last(), 5)
+        self.assertIsNone(dll.remove_last())
 
 
 


### PR DESCRIPTION
Nodes surrounding the removed node were not being updated properly.  This is fixed.  Unit tests were updated to confirm removal is correct for low length DLL and for empty DLL, which return None.