### PR TITLE
Cert conditions

### DIFF
--- a/modules/Certificate.py
+++ b/modules/Certificate.py
@@ -4,17 +4,16 @@
 # Description:  Implements an certificate for the problem to be tested as a solution.
 
 from Edge import Edge
+from Vertex import Vertex
 from Graph import Graph
-from copy import deepcopy
 
 
 class Certificate:
-    """ Accepts a set of conditions in the form of {Vertex: integer}, where
-        the vertex corresponds to the coordinates of a condition and the
+    """ Accepts a set of conditions in the form of {(x, y): integer}, where
         integer is the requirement. Collects proposed edges for a solution. """
     def __init__(self, conditions):
         self.__edges = {}
-        self.__conditions = conditions
+        self.__conditions = {Vertex(coords[0], coords[1]): value for coords, value in conditions.items()}
 
     @property
     def edges(self):

--- a/modules/Game.py
+++ b/modules/Game.py
@@ -1,0 +1,36 @@
+# Author:  Joshua Fogus
+# Course:  CS 325_400_F2020
+# Date:  December 06, 2020
+# Description:  Implements a Corral game for user input to update.
+
+from Certificate import Certificate
+
+
+class Game:
+    """ Receives a tuple of dimensions, with the 0th item being the rows and the 1st
+        item being the columns, and a dictionary of conditions in the form of
+        { x, y: integer }. """
+    def __init__(self, dimensions, conditions):
+        self.__board = [[[] for _ in range(dimensions[1])] for _ in range(dimensions[0])]
+        self.__certificate = Certificate(conditions)
+
+    @property
+    def board(self):
+        return self.__board
+
+    def print_board(self):
+        """ Pretty prints the board. """
+        for row in self.__board:
+            for col in row:
+                print(col, end=" ")
+            print()
+
+
+if __name__ == "__main__":
+    g = Game((7, 7), {
+        (1, 0): 3,
+        (2, 1): 4,
+        (1, 3): 2
+    })
+    g.print_board()
+    print("This is not meant to be run as a script. Please import this module.")

--- a/unittests/CertificateTest.py
+++ b/unittests/CertificateTest.py
@@ -13,7 +13,7 @@ class CertificateTester(unittest.TestCase):
     def test_add_edge(self):
         """ Tests adding an edge to the certificate. """
         c = Certificate({
-            Vertex(3, 5): 4
+            (3, 5): 4
         })
 
         e = Edge(Vertex(3, 3), Vertex(3, 7))
@@ -44,7 +44,7 @@ class CertificateTester(unittest.TestCase):
     def test_remove_edge(self):
         """ Tests removing an edge from the certificate. """
         c = Certificate({
-            Vertex(3, 5): 4
+            (3, 5): 4
         })
 
         e = Edge(Vertex(3, 3), Vertex(3, 7))
@@ -61,7 +61,7 @@ class CertificateTester(unittest.TestCase):
     def test_validate_edge(self):
         """ Tests that an edge meets the condition that intersects it. """
         c = Certificate({
-            Vertex(3, 5): 4
+            (3, 5): 4
         })
 
         e = Edge(Vertex(3, 3), Vertex(3, 7))
@@ -81,9 +81,9 @@ class CertificateTester(unittest.TestCase):
     def test_get_graph(self):
         """ Tests that a graph can be made from disconnected edges. """
         c = Certificate({
-            Vertex(1, 0): 3,
-            Vertex(2, 1): 4,
-            Vertex(1, 3): 2
+            (1, 0): 3,
+            (2, 1): 4,
+            (1, 3): 2
         })
 
         e = Edge(Vertex(0, 0), Vertex(3, 0))


### PR DESCRIPTION
Certificates previously accepted dictionaries with Vertex keys.  They now accept dictionaries with tuple keys corresponding to the coordinates of a vertex and convert those coordinates into a vertex.

It seemed more logical for the certificate to make this conversion instead of the game.