### PR TITLE
Certificate accepts coords

### DIFF
--- a/modules/Certificate.py
+++ b/modules/Certificate.py
@@ -19,9 +19,11 @@ class Certificate:
     def edges(self):
         return self.__edges
 
-    def add_edge(self, u, v):
+    def add_edge(self, u_coords, v_coords):
         """ Adds a valid edge to the set of edges in the certificate and returns
             True if added. Otherwise returns False. O(C) """
+        u = Vertex(u_coords[0], u_coords[1])
+        v = Vertex(v_coords[0], v_coords[1])
         edge = Edge(u, v)
 
         if self.validate_edge(edge):
@@ -31,11 +33,12 @@ class Certificate:
         return False
 
     def remove_edge(self, u, v):
-        """ Removes an edge from the set of edges in the certificate"""
-        try:
-            del self.__edges[u, v]
-        except KeyError:
-            return
+        """ Removes an edge from the set of edges in the certificate, given
+            coordinates for the edges vertices as tuples in the form (x, y). """
+        for key, edge in self.__edges.items():
+            if edge.u.x == u[0] and edge.u.y == u[1] and edge.v.x == v[0] and edge.v.y == v[1]:
+                del self.__edges[key]
+                return
 
     def validate_edge(self, edge):
         """ Confirms that an edge meets one of the conditions, returning True if

--- a/unittests/CertificateTest.py
+++ b/unittests/CertificateTest.py
@@ -16,30 +16,27 @@ class CertificateTester(unittest.TestCase):
             (3, 5): 4
         })
 
-        e = Edge(Vertex(3, 3), Vertex(3, 7))
-        f = Edge(Vertex(1, 5), Vertex(5, 5))
-        g = Edge(Vertex(2, 4), Vertex(4, 6))
-        h = Edge(Vertex(1, 9), Vertex(5, 9))
-        i = Edge(Vertex(3, 4), Vertex(3, 6))
-        j = Edge(Vertex(2, 5), Vertex(7, 5))
+        e = ((3, 3), (3, 7))
+        f = ((1, 5), (5, 5))
+        g = ((2, 4), (4, 6))
+        h = ((1, 9), (5, 9))
+        i = ((3, 4), (3, 6))
+        j = ((2, 5), (7, 5))
 
         # Valid horizontal edge
-        c.add_edge(e.u, e.v)
+        c.add_edge(e[0], e[1])
         # Valid vertical edge
-        c.add_edge(f.u, f.v)
+        c.add_edge(f[0], f[1])
         # Invalid diagonal edge
-        c.add_edge(g.u, g.v)
+        c.add_edge(g[0], g[1])
         # Invalid non-intersected edge
-        c.add_edge(h.u, h.v)
+        c.add_edge(h[0], h[1])
         # Invalid short length
-        c.add_edge(i.u, i.v)
+        c.add_edge(i[0], i[1])
         # Invalid long length
-        c.add_edge(j.u, j.v)
+        c.add_edge(j[0], j[1])
 
-        self.assertSetEqual(set(c.edges.keys()), {
-            (e.u, e.v),
-            (f.u, f.v)
-        })
+        self.assertEqual(len(set(c.edges.keys())), 2)
 
     def test_remove_edge(self):
         """ Tests removing an edge from the certificate. """
@@ -49,12 +46,12 @@ class CertificateTester(unittest.TestCase):
 
         e = Edge(Vertex(3, 3), Vertex(3, 7))
         f = Edge(Vertex(1, 5), Vertex(5, 5))
-        c.add_edge(e.u, e.v)
+        c.add_edge((3, 3), (3, 7))
 
         # Existent edge
-        c.remove_edge(e.u, e.v)
+        c.remove_edge((3, 3), (3, 7))
         # Nonexistent edge
-        c.remove_edge(f.u, f.v)
+        c.remove_edge((1, 5), (5, 5))
 
         self.assertEqual(len(c.edges), 0)
 
@@ -86,13 +83,13 @@ class CertificateTester(unittest.TestCase):
             (1, 3): 2
         })
 
-        e = Edge(Vertex(0, 0), Vertex(3, 0))
-        f = Edge(Vertex(2, 0), Vertex(2, 4))
-        g = Edge(Vertex(0, 3), Vertex(2, 3))
+        e = ((0, 0), (3, 0))
+        f = ((2, 0), (2, 4))
+        g = ((0, 3), (2, 3))
 
-        c.add_edge(e.u, e.v)
-        c.add_edge(f.u, f.v)
-        c.add_edge(g.u, g.v)
+        c.add_edge(e[0], e[1])
+        c.add_edge(f[0], f[1])
+        c.add_edge(g[0], g[1])
 
         graph = c.get_graph()
 


### PR DESCRIPTION
Add and remove edges from certificates are both performed by giving coordinates for the vertices now instead of the vertices themselves.